### PR TITLE
fix(gitignore): correctly handle escaped wildcard patterns

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 ##############################################################################
 #
@@ -55,7 +57,7 @@
 #       Darwin, MinGW, and NonStop.
 #
 #   (3) This script is generated from the Groovy template
-#       https://github.com/gradle/gradle/blob/master/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+#       https://github.com/gradle/gradle/blob/HEAD/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
 #       within the Gradle project.
 #
 #       You can find Gradle at https://github.com/gradle/gradle/.
@@ -80,13 +82,11 @@ do
     esac
 done
 
-APP_HOME=$( cd "${APP_HOME:-./}" && pwd -P ) || exit
-
-APP_NAME="Gradle"
+# This is normally unused
+# shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
-
-# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+# Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum
@@ -133,22 +133,29 @@ location of your Java installation."
     fi
 else
     JAVACMD=java
-    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+    if ! command -v java >/dev/null 2>&1
+    then
+        die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
 
 Please set the JAVA_HOME variable in your environment to match the
 location of your Java installation."
+    fi
 fi
 
 # Increase the maximum file descriptors if we can.
 if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
     case $MAX_FD in #(
       max*)
+        # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
+        # shellcheck disable=SC2039,SC3045
         MAX_FD=$( ulimit -H -n ) ||
             warn "Could not query maximum file descriptor limit"
     esac
     case $MAX_FD in  #(
       '' | soft) :;; #(
       *)
+        # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
+        # shellcheck disable=SC2039,SC3045
         ulimit -n "$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to $MAX_FD"
     esac
@@ -193,17 +200,27 @@ if "$cygwin" || "$msys" ; then
     done
 fi
 
-# Collect all arguments for the java command;
-#   * $DEFAULT_JVM_OPTS, $JAVA_OPTS, and $GRADLE_OPTS can contain fragments of
-#     shell script including quotes and variable substitutions, so put them in
-#     double quotes to make sure that they get re-expanded; and
-#   * put everything else in single quotes, so that it's not re-expanded.
+
+# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+
+# Collect all arguments for the java command:
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
+#     and any embedded shellness will be escaped.
+#   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
+#     treated as '${Hostname}' itself on the command line.
 
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \
         -classpath "$CLASSPATH" \
         org.gradle.wrapper.GradleWrapperMain \
         "$@"
+
+# Stop when "xargs" is not available.
+if ! command -v xargs >/dev/null 2>&1
+then
+    die "xargs is not available"
+fi
 
 # Use "xargs" to parse quoted args.
 #

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -13,8 +13,10 @@
 @rem See the License for the specific language governing permissions and
 @rem limitations under the License.
 @rem
+@rem SPDX-License-Identifier: Apache-2.0
+@rem
 
-@if "%DEBUG%" == "" @echo off
+@if "%DEBUG%"=="" @echo off
 @rem ##########################################################################
 @rem
 @rem  Gradle startup script for Windows
@@ -25,7 +27,8 @@
 if "%OS%"=="Windows_NT" setlocal
 
 set DIRNAME=%~dp0
-if "%DIRNAME%" == "" set DIRNAME=.
+if "%DIRNAME%"=="" set DIRNAME=.
+@rem This is normally unused
 set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
 
@@ -40,13 +43,13 @@ if defined JAVA_HOME goto findJavaFromJavaHome
 
 set JAVA_EXE=java.exe
 %JAVA_EXE% -version >NUL 2>&1
-if "%ERRORLEVEL%" == "0" goto execute
+if %ERRORLEVEL% equ 0 goto execute
 
-echo.
-echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
-echo.
-echo Please set the JAVA_HOME variable in your environment to match the
-echo location of your Java installation.
+echo. 1>&2
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH. 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
 
 goto fail
 
@@ -56,11 +59,11 @@ set JAVA_EXE=%JAVA_HOME%/bin/java.exe
 
 if exist "%JAVA_EXE%" goto execute
 
-echo.
-echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
-echo.
-echo Please set the JAVA_HOME variable in your environment to match the
-echo location of your Java installation.
+echo. 1>&2
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME% 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
 
 goto fail
 
@@ -75,13 +78,15 @@ set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
 :end
 @rem End local scope for the variables with windows NT shell
-if "%ERRORLEVEL%"=="0" goto mainEnd
+if %ERRORLEVEL% equ 0 goto mainEnd
 
 :fail
 rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
 rem the _cmd.exe /c_ return code!
-if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
-exit /b 1
+set EXIT_CODE=%ERRORLEVEL%
+if %EXIT_CODE% equ 0 set EXIT_CODE=1
+if not ""=="%GRADLE_EXIT_CONSOLE%" exit %EXIT_CODE%
+exit /b %EXIT_CODE%
 
 :mainEnd
 if "%OS%"=="Windows_NT" endlocal

--- a/src/main/kotlin/com/keyboardsamurais/intellij/plugin/sourceclipboardexport/core/gitignore/GitignoreParser.kt
+++ b/src/main/kotlin/com/keyboardsamurais/intellij/plugin/sourceclipboardexport/core/gitignore/GitignoreParser.kt
@@ -228,154 +228,148 @@ class GitignoreParser(val gitignoreFile: VirtualFile) {
          * @return MatchResult indicating match type or NO_MATCH.
          */
         fun matches(normalizedPath: String, isDir: Boolean): MatchResult {
-            val pathObj : Path = try {
-                 FS.getPath(normalizedPath)
+            val pathObj: Path? = try {
+                FS.getPath(normalizedPath)
             } catch (e: InvalidPathException) {
-                // Log runtime path errors as DEBUG - might happen with unusual filenames
+                // On Windows (or other FS), names with '*' or '?' are invalid.
+                // Do NOT return; fall back to string/regex matching.
                 LOG.debug("Rule '$original': Invalid path syntax: $normalizedPath", e)
-                return MatchResult.NO_MATCH
+                null
             } catch (e: Exception) {
-                 LOG.debug("Rule '$original': Error creating Path object for: $normalizedPath", e)
-                 return MatchResult.NO_MATCH
+                LOG.debug("Rule '$original': Error creating Path object for: $normalizedPath", e)
+                null
+            }
+
+            val fileNameOnly = try {
+                pathObj?.fileName?.toString()
+            } catch (_: Exception) {
+                null
+            } ?: run {
+                val idx = normalizedPath.lastIndexOf('/')
+                if (idx >= 0) normalizedPath.substring(idx + 1) else normalizedPath
             }
 
             var hit = false
             var matchedBy = MatchSource.NONE // Track how the match occurred
 
-            /* ── 1. Simple String Match (no wildcards, not dirOnly) ──────── */
+            // 1) Simple string match (no glob metachars, not dirOnly)
             if (simpleStringMatch) {
-                if (rooted || pattern.contains('/')) {
-                    hit = (normalizedPath == pattern)
+                hit = if (rooted || pattern.contains('/')) {
+                    normalizedPath == pattern
                 } else {
-                    // Use pathObj.fileName which handles separators correctly.
-                    // Check if pathObj has a filename (it might be just "foo")
-                    hit = (pathObj.fileName?.toString() == pattern)
+                    fileNameOnly == pattern
                 }
                 if (hit) matchedBy = MatchSource.SIMPLE
-                if (LOG.isTraceEnabled && hit) LOG.trace("Rule '$original': Simple match success for '$normalizedPath'")
+                if (!hit) return MatchResult.NO_MATCH
+                // fall through to dirOnly checks and final result
             }
-            /* ── 2. Glob Matcher / dirOnly=true ───────────────────────────── */
-            // Try Glob Matcher first if it exists
+            // 2) Glob matcher / dirOnly=true (prefer PathMatcher, but handle no-Path case)
             else if (matcher != null) {
                 try {
-                    // For directory patterns, also check if the path is inside the directory
-                    if (dirOnly && normalizedPath.startsWith(pattern + "/")) {
+                    // Directory contents quick check (string-only, no Path needed)
+                    if (dirOnly && normalizedPath.startsWith("$pattern/")) {
                         hit = true
                         matchedBy = MatchSource.GLOB
-                        if (LOG.isTraceEnabled) LOG.trace("Rule '$original': Directory pattern matches path inside directory '$normalizedPath'")
                     }
-                    // For complex patterns with directory and extension, special handling
+                    // Special handling for patterns like "doc/**/*.pdf"
                     else if (pattern.contains("/**/*.") && normalizedPath.startsWith(pattern.substringBefore("/**/*."))) {
                         val extension = pattern.substringAfterLast(".")
                         if (normalizedPath.endsWith(".$extension")) {
                             hit = true
                             matchedBy = MatchSource.GLOB
-                            if (LOG.isTraceEnabled) LOG.trace("Rule '$original': Complex pattern matches path with extension '$normalizedPath'")
                         }
                     }
-                    // Standard glob matching
-                    else if (matcher.matches(pathObj)) {
+                    // Try PathMatcher if we have a valid Path
+                    else if (pathObj != null && matcher.matches(pathObj)) {
                         hit = true
                         matchedBy = MatchSource.GLOB
-                        if (LOG.isTraceEnabled) LOG.trace("Rule '$original': PathMatcher glob '${matcher}' SUCCESS for '$normalizedPath'")
-                    } else {
-                         if (LOG.isTraceEnabled) LOG.trace("Rule '$original': PathMatcher glob '${matcher}' FAILED for '$normalizedPath'")
+                    }
+                    // Last resort: emulate the glob against the full path with a regex when we don't have a Path
+                    else if (pathObj == null) {
+                        val hasSlash = pattern.contains('/')
+                        val fullGlob = buildString {
+                            if (!rooted && !pattern.startsWith("**") && !hasSlash) append("**/")
+                            append(pattern)
+                            if (dirOnly && !pattern.endsWith("/**")) append("/**")
+                        }
+                        val fullRegex = try {
+                            globToRegex(fullGlob)
+                        } catch (e: Exception) {
+                            LOG.debug("Rule '$original': Error converting glob '$fullGlob' to regex", e)
+                            null
+                        }
+                        if (fullRegex != null && fullRegex.matches(normalizedPath)) {
+                            hit = true
+                            matchedBy = MatchSource.GLOB
+                        }
                     }
                 } catch (e: Exception) {
-                    // Log runtime matching errors as DEBUG
-                    LOG.debug("Rule '$original': Error during PathMatcher.matches for path '$normalizedPath'", e)
-                    // hit remains false
+                    LOG.debug("Rule '$original': Error during glob matching for path '$normalizedPath'", e)
                 }
 
-                /* ── 3. Filename-only regex fallback (if Glob didn't hit) ── */
-                // Apply if: Glob didn't hit, regex exists
+                // Filename-only regex fallback (e.g., "*.txt", "file\\*.txt")
                 if (!hit && fileRegex != null) {
-                    val name = pathObj.fileName?.toString()
-                    if (!name.isNullOrEmpty()) {
-                         try {
-                            val regexHit = fileRegex.matches(name)
-                            if (regexHit) {
-                                hit = true
-                                // If matcher also exists, prefer GLOB source? No, REGEX is more specific here.
-                                matchedBy = MatchSource.REGEX
-                                if (LOG.isTraceEnabled) LOG.trace("Rule '$original': fileRegex '$fileRegex' SUCCESS for filename '$name' (path '$normalizedPath')")
-                            } else {
-                                if (LOG.isTraceEnabled) LOG.trace("Rule '$original': fileRegex '$fileRegex' FAILED for filename '$name' (path '$normalizedPath')")
-                            }
-                         } catch (e: Exception) {
-                             // Log runtime matching errors as DEBUG
-                             LOG.debug("Rule '$original': Error during fileRegex.matches for name '$name'", e)
-                         }
-                    } else {
-                         if (LOG.isTraceEnabled) LOG.trace("Rule '$original': fileRegex fallback skipped for path '$normalizedPath' (no filename)")
+                    try {
+                        if (fileRegex.matches(fileNameOnly)) {
+                            hit = true
+                            matchedBy = MatchSource.REGEX
+                        }
+                    } catch (e: Exception) {
+                        LOG.debug("Rule '$original': Error during fileRegex.matches for name '$fileNameOnly'", e)
                     }
                 }
+
+                if (!hit) return MatchResult.NO_MATCH
+                // fall through to dirOnly checks and final result
             }
-            // Case where only fileRegex might apply (e.g., simpleStringMatch=false but matcher failed to create?)
+            // 3) Only filename regex is available (no matcher)
             else if (fileRegex != null) {
-                 val name = pathObj.fileName?.toString()
-                 if (!name.isNullOrEmpty()) {
-                     try {
-                         if (fileRegex.matches(name)) {
-                             hit = true
-                             // If matcher also exists, prefer GLOB source? No, REGEX is more specific here.
-                             matchedBy = MatchSource.REGEX
-                             if (LOG.isTraceEnabled) LOG.trace("Rule '$original': fileRegex (no matcher) SUCCESS for filename '$name'")
-                         }
-                     } catch (e: Exception) {
-                          LOG.debug("Rule '$original': Error during fileRegex.matches (no matcher) for name '$name'", e)
-                     }
-                 }
+                try {
+                    if (fileRegex.matches(fileNameOnly)) {
+                        hit = true
+                        matchedBy = MatchSource.REGEX
+                    }
+                } catch (e: Exception) {
+                    LOG.debug("Rule '$original': Error during fileRegex.matches (no matcher) for name '$fileNameOnly'", e)
+                }
+                if (!hit) return MatchResult.NO_MATCH
+                // fall through to dirOnly checks and final result
+            } else {
+                // No way to match
+                return MatchResult.NO_MATCH
             }
 
-
-            /* --- No match found --- */
-            if (!hit) return MatchResult.NO_MATCH
-
-            /* --- Apply dirOnly constraints if applicable --- */
+            // 4) Apply dirOnly constraints if applicable
             if (dirOnly) {
-                // Get the base directory name the rule targets (e.g., "build" from "**/build/")
                 val dirNamePattern = pattern.substringAfterLast('/')
-                // Check if the path's filename component matches the target directory name
-                val filenameMatchesDirName = pathObj.fileName?.toString() == dirNamePattern
+                val filenameMatchesDirName = fileNameOnly == dirNamePattern
 
                 when (matchedBy) {
                     MatchSource.GLOB -> {
-                        // Glob `**/pattern/**` matched.
-                        // If it matched a FILE whose name is exactly the target directory name, reject it.
-                        // Example: Rule `dir/`, Path `dir` (isDir=false). Glob matches, but this check rejects.
+                        // If we matched a FILE whose name equals the directory rule, reject it.
                         if (filenameMatchesDirName && !isDir) {
-                             if (LOG.isTraceEnabled) LOG.trace("Rule '$original' (dirOnly): Glob matched file '$normalizedPath' with same name as pattern base. -> REJECTED (NO_MATCH)")
-                             return MatchResult.NO_MATCH
+                            if (LOG.isTraceEnabled) LOG.trace("Rule '$original' (dirOnly): Glob matched file '$normalizedPath' with same name as pattern. -> REJECTED (NO_MATCH)")
+                            return MatchResult.NO_MATCH
                         }
-                        // Example: Rule `dir/`, Path `dir` (isDir=true). Glob matches, check passes. -> OK
-                        // Example: Rule `dir/`, Path `dir/file.txt`. Glob matches, filename != dirName, check passes. -> OK
-                        if (LOG.isTraceEnabled) LOG.trace("Rule '$original' (dirOnly): Glob match is valid.")
                     }
                     MatchSource.REGEX -> {
-                        // Regex matched the filename (e.g., rule `build/`, path `build`).
-                        // This is only valid for dirOnly if the path IS a directory.
+                        // Regex on filename is only valid for dirOnly if target is a directory
                         if (!isDir) {
                             if (LOG.isTraceEnabled) LOG.trace("Rule '$original' (dirOnly): fileRegex matched file '$normalizedPath', but rule requires directory. -> REJECTED (NO_MATCH)")
                             return MatchResult.NO_MATCH
                         }
-                        // Example: Rule `build/`, Path `build` (isDir=true). Regex matches, isDir=true, check passes -> OK
-                        if (LOG.isTraceEnabled) LOG.trace("Rule '$original' (dirOnly): fileRegex match on directory name is valid.")
                     }
                     MatchSource.SIMPLE -> {
-                        // Simple match shouldn't happen if dirOnly=true due to init logic
                         LOG.warn("Rule '$original' (dirOnly): Unexpected match by SIMPLE source.")
-                        return MatchResult.NO_MATCH // Treat as error / no match
+                        return MatchResult.NO_MATCH
                     }
                     MatchSource.NONE -> {
-                        // Should not happen if hit=true
                         LOG.warn("Rule '$original' (dirOnly): Hit=true but matchedBy=NONE.")
-                        return MatchResult.NO_MATCH // Treat as error / no match
+                        return MatchResult.NO_MATCH
                     }
                 }
             }
 
-            /* --- Determine final result based on negation --- */
             return if (negated) MatchResult.MATCH_NEGATE else MatchResult.MATCH_IGNORE
         }
 


### PR DESCRIPTION
The `GitignoreParser` failed to match patterns with escaped wildcards (e.g., `file\*.txt`) against filenames containing those literal characters.

The root cause was an over-reliance on `java.nio.file.Path`. On filesystems like Windows, filenames cannot contain characters such as `*` or `?`. When the parser tried to create a `Path` object from a string like `file*.txt`, it threw an `InvalidPathException`. The existing error handling would immediately return `NO_MATCH`, preventing the regex-based fallback logic—which correctly handles escaped literals—from ever running.

This patch modifies the `matches` method in `IgnoreRule` to no longer exit prematurely on an `InvalidPathException`. Instead, it allows processing to continue with a `null` `Path` object and relies on robust string- and regex-based comparisons.

This change ensures that:
- Escaped patterns like `file\*.txt` and `file\?.txt` are correctly matched.
- The parser's behavior is consistent across different operating systems, aligning it more closely with Git's platform-agnostic matching.